### PR TITLE
Minor capitalization correction for GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ And a "probably up-to-date" list of currently-implemented modules:
 * [Command Runner](http://wtfutil.com/posts/modules/cmdrunner/)
 * [Google Calendar](http://wtfutil.com/posts/modules/gcal/)
 * [Git](http://wtfutil.com/posts/modules/git/)
-* [Github](http://wtfutil.com/posts/modules/github/)
+* [GitHub](http://wtfutil.com/posts/modules/github/)
 * [Jira](http://wtfutil.com/posts/modules/jira/)
 * [New Relic](http://wtfutil.com/posts/modules/newrelic/)
 * [OpsGenie](http://wtfutil.com/posts/modules/opsgenie)


### PR DESCRIPTION
GitHub uses a capital 'H' 🤓
https://github.com
![](https://cloud.githubusercontent.com/assets/49038/26196161/fa47fb1a-3bb5-11e7-978f-29c4af682648.png)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
