### PR TITLE
Fixing the NewRelic deployments slice issue

### DIFF
--- a/newrelic/widget.go
+++ b/newrelic/widget.go
@@ -70,7 +70,7 @@ func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
 
 			str = str + fmt.Sprintf(
 				" [green]%s[%s] %s %-.16s[white]\n",
-				deploy.Revision[0:8],
+				deploy.Revision[0:],
 				lineColor,
 				deploy.Timestamp.Format("Jan 02, 15:04 MST"),
 				wtf.NameFromEmail(deploy.User),


### PR DESCRIPTION
This fails with an unbound slice error when the revision value is smaller