### PR TITLE
linux/ubuntu wraps for security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dependencies:
 	go get -v ./...
 
 install:
-	which wtf | xargs rm
+	which wtf | xargs rm || true
 	go install -ldflags="-X main.version=$(shell git describe --always --abbrev=6)_$(BRANCH) -X main.date=$(shell date +%FT%T%z)"
 	which wtf
 

--- a/security/dns.go
+++ b/security/dns.go
@@ -39,7 +39,7 @@ func DnsServers() []string {
 	switch runtime.GOOS {
 	case "linux":
 		return dnsLinux()
-	case "macos":
+	case "darwin":
 		return dnsMacOS()
 	default:
 		return []string{runtime.GOOS}

--- a/security/firewall.go
+++ b/security/firewall.go
@@ -27,7 +27,7 @@ func FirewallState() string {
 	switch runtime.GOOS {
 	case "linux":
 		return firewallStateLinux()
-	case "macos":
+	case "darwin":
 		return firewallStateMacOS()
 	default:
 		return ""
@@ -49,7 +49,7 @@ func FirewallStealthState() string {
 	switch runtime.GOOS {
 	case "linux":
 		return firewallStealthStateLinux()
-	case "macos":
+	case "darwin":
 		return firewallStealthStateMacOS()
 	default:
 		return ""

--- a/security/firewall.go
+++ b/security/firewall.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/senorprogrammer/wtf/wtf"
@@ -11,18 +12,49 @@ const osxFirewallCmd = "/usr/libexec/ApplicationFirewall/socketfilterfw"
 
 /* -------------------- Exported Functions -------------------- */
 
-func FirewallState() string {
+func firewallStateLinux() string {
+	return "[red]NA[white]"
+}
+
+func firewallStateMacOS() string {
 	cmd := exec.Command(osxFirewallCmd, "--getglobalstate")
 	str := wtf.ExecuteCommand(cmd)
 
 	return status(str)
 }
 
-func FirewallStealthState() string {
+func FirewallState() string {
+	switch runtime.GOOS {
+	case "linux":
+		return firewallStateLinux()
+	case "macos":
+		return firewallStateMacOS()
+	default:
+		return ""
+	}
+}
+
+func firewallStealthStateLinux() string {
+	return "[red]NA[white]"
+}
+
+func firewallStealthStateMacOS() string {
 	cmd := exec.Command(osxFirewallCmd, "--getstealthmode")
 	str := wtf.ExecuteCommand(cmd)
 
 	return status(str)
+}
+
+func FirewallStealthState() string {
+	q
+	switch runtime.GOOS {
+	case "linux":
+		return firewallStealthStateLinux()
+	case "macos":
+		return firewallStealthStateMacOS()
+	default:
+		return ""
+	}
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/security/firewall.go
+++ b/security/firewall.go
@@ -46,7 +46,6 @@ func firewallStealthStateMacOS() string {
 }
 
 func FirewallStealthState() string {
-	q
 	switch runtime.GOOS {
 	case "linux":
 		return firewallStealthStateLinux()

--- a/security/security_data.go
+++ b/security/security_data.go
@@ -1,11 +1,7 @@
 package security
 
-import (
-	"strings"
-)
-
 type SecurityData struct {
-	Dns             string
+	Dns             []string
 	FirewallEnabled string
 	FirewallStealth string
 	LoggedInUsers   []string
@@ -17,14 +13,11 @@ func NewSecurityData() *SecurityData {
 	return &SecurityData{}
 }
 
-func (data *SecurityData) DnsAt(idx int) string {
-	records := strings.Split(data.Dns, "\n")
-
-	if len(records) > 0 && len(records) > idx {
-		return records[idx]
-	} else {
-		return ""
+func (data SecurityData) DnsAt(idx int) string {
+	if len(data.Dns) > idx {
+		return data.Dns[idx]
 	}
+	return ""
 }
 
 func (data *SecurityData) Fetch() {

--- a/security/users.go
+++ b/security/users.go
@@ -2,18 +2,54 @@ package security
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/senorprogrammer/wtf/wtf"
 )
 
-// http://applehelpwriter.com/2017/05/21/how-to-reveal-hidden-users/
+func loggedInUsersLinux() []string {
+	cmd := exec.Command("who", "-us")
+	users := wtf.ExecuteCommand(cmd)
 
-func LoggedInUsers() []string {
+	cleaned := []string{}
+	for _, u := range strings.Split(users, "\n") {
+		clean := true
+		col := strings.Split(u, " ")
+		if len(col) > 0 {
+			for _, cleanedU := range cleaned {
+				if strings.Compare(cleanedU, col[0]) == 0 {
+					clean = false
+				}
+			}
+			if clean {
+				cleaned = append(cleaned, col[0])
+			}
+		}
+
+	}
+
+	return cleaned
+}
+
+func loggedInUsersMacOs() []string {
 	cmd := exec.Command("dscl", []string{".", "-list", "/Users"}...)
 	users := wtf.ExecuteCommand(cmd)
 
 	return cleanUsers(strings.Split(users, "\n"))
+}
+
+// http://applehelpwriter.com/2017/05/21/how-to-reveal-hidden-users/
+
+func LoggedInUsers() []string {
+	switch runtime.GOOS {
+	case "linux":
+		return loggedInUsersLinux()
+	case "macos":
+		return loggedInUsersMacOs()
+	default:
+		return []string{}
+	}
 }
 
 func cleanUsers(users []string) []string {

--- a/security/users.go
+++ b/security/users.go
@@ -45,7 +45,7 @@ func LoggedInUsers() []string {
 	switch runtime.GOOS {
 	case "linux":
 		return loggedInUsersLinux()
-	case "macos":
+	case "darwin":
 		return loggedInUsersMacOs()
 	default:
 		return []string{}

--- a/security/wifi.go
+++ b/security/wifi.go
@@ -32,7 +32,7 @@ func WifiEncryption() string {
 	switch runtime.GOOS {
 	case "linux":
 		return wifiEncryptionLinux()
-	case "macos":
+	case "darwin":
 		return wifkEncryptionMacOS()
 	default:
 		return ""
@@ -58,7 +58,7 @@ func WifiName() string {
 	switch runtime.GOOS {
 	case "linux":
 		return wifiNameLinux()
-	case "macos":
+	case "darwin":
 		return wifiNameMacOS()
 	default:
 		return ""

--- a/security/wifi.go
+++ b/security/wifi.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"os/exec"
+	"runtime"
 
 	"github.com/senorprogrammer/wtf/wtf"
 )
@@ -12,14 +13,56 @@ const osxWifiArg = "-I"
 
 /* -------------------- Exported Functions -------------------- */
 
-func WifiEncryption() string {
+func wifiEncryptionLinux() string {
+	cmd := exec.Command("nmcli", "-t", "-f", "active,security", "dev", "wifi")
+	out := wtf.ExecuteCommand(cmd)
+	name := wtf.FindMatch(`yes:(.+)`, out)
+	if len(name) > 0 {
+		return name[0][1]
+	}
+	return ""
+}
+
+func wifkEncryptionMacOS() string {
 	name := wtf.FindMatch(`s*auth: (.+)s*`, wifiInfo())
 	return matchStr(name)
 }
 
-func WifiName() string {
+func WifiEncryption() string {
+	switch runtime.GOOS {
+	case "linux":
+		return wifiEncryptionLinux()
+	case "macos":
+		return wifkEncryptionMacOS()
+	default:
+		return ""
+	}
+}
+
+func wifiNameMacOS() string {
 	name := wtf.FindMatch(`s*SSID: (.+)s*`, wifiInfo())
 	return matchStr(name)
+}
+
+func wifiNameLinux() string {
+	cmd := exec.Command("nmcli", "-t", "-f", "active,ssid", "dev", "wifi")
+	out := wtf.ExecuteCommand(cmd)
+	name := wtf.FindMatch(`yes:(.+)`, out)
+	if len(name) > 0 {
+		return name[0][1]
+	}
+	return ""
+}
+
+func WifiName() string {
+	switch runtime.GOOS {
+	case "linux":
+		return wifiNameLinux()
+	case "macos":
+		return wifiNameMacOS()
+	default:
+		return ""
+	}
 }
 
 /* -------------------- Unexported Functions -------------------- */


### PR DESCRIPTION
Updates the `security` module to work with Linux. Uses runtime.GOOS to use platform specific methods.

Could use `// +build linux` to potentially only compile in funcs for each platform as well, but this is proof of concepts AFAIK.

Partly addresses #94