### PR TITLE
Feat: add an error message when WTF was failed

### DIFF
--- a/wtf.go
+++ b/wtf.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -232,6 +233,7 @@ func main() {
 	go watchForConfigChanges(app, cmdFlags.Config, grid, pages)
 
 	if err := app.SetRoot(pages, true).Run(); err != nil {
+		fmt.Printf("An error occurred: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is just a minor change to avoid a small number of inexperienced
users not be intimidated by a minor mistake, such as the incorrect
setting of the TERM environment variable.

I hope this will be improved a bit of user experience for let WTF
more popular.