### PR TITLE
Moving git recent commits above changed files

### DIFF
--- a/git/display.go
+++ b/git/display.go
@@ -24,9 +24,9 @@ func (widget *Widget) display() {
 	str = str + " [red]Branch[white]\n"
 	str = str + fmt.Sprintf(" %s", repoData.Branch)
 	str = str + "\n"
-	str = str + widget.formatChanges(repoData.ChangedFiles)
-	str = str + "\n"
 	str = str + widget.formatCommits(repoData.Commits)
+	str = str + "\n"
+	str = str + widget.formatChanges(repoData.ChangedFiles)
 
 	fmt.Fprintf(widget.View, "%s", str)
 }


### PR DESCRIPTION
When you have many changed files, recent commits can be pushed outside of the screen.

Since only the changed files list takes a config parameter to control how many are displayed, I thought it made more sense to have it on top.