### PR TITLE
Fix "When deleting a todo item, select the next item up if there is one"

### DIFF
--- a/todo/list.go
+++ b/todo/list.go
@@ -33,6 +33,9 @@ func (list *List) CheckedItems() []*Item {
 
 func (list *List) Delete() {
 	list.Items = append(list.Items[:list.selected], list.Items[list.selected+1:]...)
+	if list.selected >= len(list.Items) {
+		list.selected--
+	}
 }
 
 func (list *List) Demote() {


### PR DESCRIPTION
This appears to be an issue when deleting the last item in a list in the todo module. This simply implements a check to decrement the selected if a user deletes the last item in a list, else, it behaves normally. 

Fixes issue: https://github.com/senorprogrammer/wtf/issues/101

Thanks, and let me know if you have any feedback!