### PR TITLE
Bug fix: lsb_release, Improvement: Power mod for Linux

### DIFF
--- a/bamboohr/calendar.go
+++ b/bamboohr/calendar.go
@@ -1,7 +1,5 @@
 package bamboohr
 
-import ()
-
 type Calendar struct {
 	Items []Item `xml:"item"`
 }

--- a/bamboohr/employee.go
+++ b/bamboohr/employee.go
@@ -1,7 +1,5 @@
 package bamboohr
 
-import ()
-
 /*
 * Note: this currently implements the minimum number of fields to fulfill the Away functionality.
 * Undoubtedly there are more fields than this to an employee

--- a/jira/issues.go
+++ b/jira/issues.go
@@ -1,8 +1,5 @@
 package jira
 
-import (
-)
-
 type Issue struct {
 	Expand string `json:"expand"`
 	ID     string `json:"id"`

--- a/jira/search_result.go
+++ b/jira/search_result.go
@@ -1,7 +1,5 @@
 package jira
 
-import ()
-
 type SearchResult struct {
 	StartAt    int     `json:"startAt"`
 	MaxResults int     `json:"maxResults"`

--- a/power/battery_linux.go
+++ b/power/battery_linux.go
@@ -23,13 +23,7 @@ type Battery struct {
 }
 
 func NewBattery() *Battery {
-	var battery *Battery
-	//sh := `upower -i $(upower -e | grep '/battery') | grep --color=never -E "state|to\ full|to\ empty|percentage"`
-	battery = &Battery{
-		//args: []string{"-c", sh},
-		//cmd:  "/bin/sh",
-	}
-	return battery
+	return &Battery{}
 }
 
 /* -------------------- Exported Functions -------------------- */

--- a/power/battery_linux.go
+++ b/power/battery_linux.go
@@ -1,18 +1,17 @@
-// +build !linux
+// +build linux
 
 package power
 
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/senorprogrammer/wtf/wtf"
 )
 
-const TimeRegExp = "^(?:\\d|[01]\\d|2[0-3]):[0-5]\\d"
+var batteryState string
 
 type Battery struct {
 	args   []string
@@ -24,12 +23,13 @@ type Battery struct {
 }
 
 func NewBattery() *Battery {
-	battery := Battery{
-		args: []string{"-g", "batt"},
-		cmd:  "pmset",
+	var battery *Battery
+	//sh := `upower -i $(upower -e | grep '/battery') | grep --color=never -E "state|to\ full|to\ empty|percentage"`
+	battery = &Battery{
+		//args: []string{"-c", sh},
+		//cmd:  "/bin/sh",
 	}
-
-	return &battery
+	return battery
 }
 
 /* -------------------- Exported Functions -------------------- */
@@ -46,37 +46,48 @@ func (battery *Battery) String() string {
 /* -------------------- Unexported Functions -------------------- */
 
 func (battery *Battery) execute() string {
-	cmd := exec.Command(battery.cmd, battery.args...)
+	cmd := exec.Command("upower", "-e")
+	lines := strings.Split(wtf.ExecuteCommand(cmd), "\n")
+	var target string
+	for _, l := range lines {
+		if strings.Contains(l, "/battery") {
+			target = l
+			break
+		}
+	}
+	cmd = exec.Command("upower", "-i", target)
 	return wtf.ExecuteCommand(cmd)
 }
 
 func (battery *Battery) parse(data string) string {
 	lines := strings.Split(data, "\n")
 	if len(lines) < 2 {
-		return "unknown (1)"
+		return "unknown"
 	}
-
-	stats := strings.Split(lines[1], "\t")
-	if len(stats) < 2 {
-		return "unknown (2)"
+	table := make(map[string]string)
+	for _, line := range lines {
+		parts := strings.Split(line, ":")
+		if len(parts) < 2 {
+			continue
+		}
+		table[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 	}
-
-	details := strings.Split(stats[1], "; ")
-	if len(details) < 3 {
-		return "unknown (3)"
+	if s := table["time to empty"]; s == "" {
+		table["time to empty"] = "∞"
 	}
-
 	str := ""
-	str = str + fmt.Sprintf(" %10s: %s\n", "Charge", battery.formatCharge(details[0]))
-	str = str + fmt.Sprintf(" %10s: %s\n", "Remaining", battery.formatRemaining(details[2]))
-	str = str + fmt.Sprintf(" %10s: %s\n", "State", battery.formatState(details[1]))
-
+	str = str + fmt.Sprintf(" %10s: %s\n", "Charge", battery.formatCharge(table["percentage"]))
+	str = str + fmt.Sprintf(" %10s: %s\n", "Remaining", table["time to empty"])
+	str = str + fmt.Sprintf(" %10s: %s\n", "State", battery.formatState(table["state"]))
+	if s := table["time to full"]; s != "" {
+		str = str + fmt.Sprintf(" %10s: %s\n", "TimeToFull", table["time to full"])
+	}
+	batteryState = table["state"]
 	return str
 }
 
 func (battery *Battery) formatCharge(data string) string {
 	percent, _ := strconv.ParseFloat(strings.Replace(data, "%", "", -1), 32)
-
 	color := ""
 
 	switch {
@@ -89,17 +100,6 @@ func (battery *Battery) formatCharge(data string) string {
 	}
 
 	return color + data + "[white]"
-}
-
-func (battery *Battery) formatRemaining(data string) string {
-	r, _ := regexp.Compile(TimeRegExp)
-
-	result := r.FindString(data)
-	if result == "" {
-		result = "∞"
-	}
-
-	return result
 }
 
 func (battery *Battery) formatState(data string) string {

--- a/power/source.go
+++ b/power/source.go
@@ -1,3 +1,5 @@
+// +build !linux
+
 package power
 
 import (

--- a/power/source_linux.go
+++ b/power/source_linux.go
@@ -1,0 +1,15 @@
+// +build linux
+
+package power
+
+// powerSource returns the name of the current power source, probably one of
+// "AC Power" or "Battery Power"
+func powerSource() string {
+	switch batteryState {
+	case "charging":
+		return "AC Power"
+	case "discharging":
+		return "Battery Power"
+	}
+	return batteryState
+}

--- a/power/source_linux.go
+++ b/power/source_linux.go
@@ -6,7 +6,7 @@ package power
 // "AC Power" or "Battery Power"
 func powerSource() string {
 	switch batteryState {
-	case "charging":
+	case "charging", "fully-charged":
 		return "AC Power"
 	case "discharging":
 		return "Battery Power"

--- a/system/system_info.go
+++ b/system/system_info.go
@@ -22,7 +22,8 @@ func NewSystemInfo() *SystemInfo {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "linux":
-		cmd = exec.Command("uname -a", arg...)
+		arg = append(arg, "-a")
+		cmd = exec.Command("lsb_release", arg...)
 	case "darwin":
 		cmd = exec.Command("sw_vers", arg...)
 	default:
@@ -33,7 +34,6 @@ func NewSystemInfo() *SystemInfo {
 
 	for _, row := range strings.Split(raw, "\n") {
 		parts := strings.Split(row, ":")
-
 		if len(parts) < 2 {
 			continue
 		}

--- a/todo/item.go
+++ b/todo/item.go
@@ -1,7 +1,5 @@
 package todo
 
-import ()
-
 type Item struct {
 	Checked bool
 	Text    string

--- a/wtf/position.go
+++ b/wtf/position.go
@@ -1,7 +1,5 @@
 package wtf
 
-import ()
-
 type Position struct {
 	top    int
 	left   int

--- a/wtf_tests/utils_test.go
+++ b/wtf_tests/utils_test.go
@@ -3,8 +3,8 @@ package wtf_tests
 import (
 	"testing"
 
-	. "github.com/senorprogrammer/wtf/wtf"
 	"github.com/go-test/deep"
+	. "github.com/senorprogrammer/wtf/wtf"
 )
 
 /* -------------------- Exclude() -------------------- */


### PR DESCRIPTION
```go
// cmd = exec.Command("lsb_release -a", arg...)
// exec: "lsb_release -a": executable file not found in $PATH

// cmd = exec.Command("lsb_release", "-a")
```
Just put `-a` in `arg`, tested on Arch Linux

`pmset` doesn't work on Linux, `upower` works, tested on Arch Linux