### PR TITLE
Fix issue #89

### DIFF
--- a/security/dns.go
+++ b/security/dns.go
@@ -42,7 +42,7 @@ func dnsLinux() []string {
 }
 
 func dnsMacOS() []string {
-	cmdString := `scutil --dns | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'`
+	cmdString := `scutil --dns | head -n 7 | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'`
 	cmd := exec.Command("sh", "-c", cmdString)
 	out := wtf.ExecuteCommand(cmd)
 

--- a/security/dns.go
+++ b/security/dns.go
@@ -42,7 +42,8 @@ func dnsLinux() []string {
 }
 
 func dnsMacOS() []string {
-	cmd := exec.Command("networksetup", "-getdnsservers", "Wi-Fi")
+	cmdString := `scutil --dns | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'`
+	cmd := exec.Command("sh", "-c", cmdString)
 	out := wtf.ExecuteCommand(cmd)
 
 	lines := strings.Split(out, "\n")


### PR DESCRIPTION
Better handle dns on macOS

use the command 
`scutil --dns | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'`
to get dns on macOS