### PR TITLE
Allow use of project list in Jira module config

### DIFF
--- a/jira/client.go
+++ b/jira/client.go
@@ -12,11 +12,12 @@ import (
 	"strings"
 )
 
-func IssuesFor(username string, project string, jql string) (*SearchResult, error) {
+func IssuesFor(username string, projects []string, jql string) (*SearchResult, error) {
 	query := []string{}
 
-	if project != "" {
-		query = append(query, buildJql("project", project))
+	var projQuery = getProjectQuery(projects)
+	if projQuery != "" {
+		query = append(query, projQuery)
 	}
 
 	if username != "" {
@@ -87,4 +88,19 @@ func parseJson(obj interface{}, text io.Reader) {
 			panic(err)
 		}
 	}
+}
+
+func getProjectQuery(projects []string) string {
+	singleEmptyProject := len(projects) == 1 && len(projects[0]) == 0
+	if len(projects) == 0 || singleEmptyProject {
+		return ""
+	} else if len(projects) == 1 {
+		return buildJql("project", projects[0])
+	}
+
+	quoted := make([]string, len(projects))
+	for i := range projects {
+		quoted[i] = fmt.Sprintf("\"%s\"", projects[i])
+	}
+	return fmt.Sprintf("project in (%s)", strings.Join(quoted, ", "))
 }

--- a/jira/widget.go
+++ b/jira/widget.go
@@ -25,7 +25,7 @@ func NewWidget() *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	searchResult, err := IssuesFor(Config.UString("wtf.mods.jira.username"), Config.UString("wtf.mods.jira.project", ""), Config.UString("wtf.mods.jira.jql", ""))
+	searchResult, err := IssuesFor(Config.UString("wtf.mods.jira.username"), getProjects(), Config.UString("wtf.mods.jira.jql", ""))
 
 	widget.UpdateRefreshedAt()
 
@@ -80,4 +80,22 @@ func (widget *Widget) issueTypeColor(issue *Issue) string {
 	}
 
 	return color
+}
+
+func getProjects() []string {
+	// see if project is set to a single string
+	configPath := "wtf.mods.jira.project"
+	singleProject, err := Config.String(configPath)
+	if err == nil {
+		return []string{singleProject}
+	}
+	// else, assume list
+	projList := Config.UList(configPath)
+	var ret []string
+	for _, proj := range projList {
+		if str, ok := proj.(string); ok {
+			ret = append(ret, str)
+		}
+	}
+	return ret
 }


### PR DESCRIPTION
For my own use case (and anyone in a similar situation), the Jira
module is more useful if I can specify a list of projects to
display issues from, rather than no project (which selects all
projects) or one specific project.

New supported syntax:
`  project: ["PROJA", "PROJB"]`

If this is merged, documentation for the Jira module should be
updated accordingly. (Sorry, I would have done this myself but
I'm not sure what the right place is - when grepping I find
multiple places in the repo containing documentation strings
and I'm not sure what the "master" location is)

Specifying a single project (or no project) is still supported -
behavior shouldn't change for anyone who doesn't change their
config.