### PR TITLE
Fix newline in git module repo names breaking display

### DIFF
--- a/git/git_repo.go
+++ b/git/git_repo.go
@@ -22,7 +22,7 @@ func NewGitRepo(repoPath string) *GitRepo {
 	repo.Branch = repo.branch()
 	repo.ChangedFiles = repo.changedFiles()
 	repo.Commits = repo.commits()
-	repo.Repository = repo.repository()
+	repo.Repository = strings.TrimSpace(repo.repository())
 
 	return &repo
 }


### PR DESCRIPTION
After setting up the git module with multiple repos and switching
between them, I observed some graphical wonkiness in the display:

![](https://i.imgur.com/R3e7eij.png)

After adding some log statements, I tracked it down to the
`GitRepo.Repository` field having a newline in it after it's set
from a command execution's stdout. This change strips the
repository path of spaces when assigning to the `Repository` field,
which fixes the display issues.