### PR TITLE
Add circleci module

### DIFF
--- a/circleci/build.go
+++ b/circleci/build.go
@@ -1,0 +1,10 @@
+package circleci
+
+type Build struct {
+	AuthorEmail        string            `json:"author_email"`
+	AuthorName         string            `json:"author_name"`
+	Branch             string            `json:"branch"`
+	BuildNum           int               `json:"build_num"`
+	Reponame           string            `json:"reponame"`
+	Status             string            `json:"status"`
+}

--- a/circleci/client.go
+++ b/circleci/client.go
@@ -1,0 +1,80 @@
+package circleci
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+const APIEnvKey = "WTF_CIRCLE_API_KEY"
+
+func BuildsFor() ([]*Build, error) {
+	builds := []*Build{}
+
+	resp, err := circleRequest("recent-builds")
+	if err != nil {
+		return builds, err
+	}
+
+	parseJson(&builds, resp.Body)
+
+	return builds, nil
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+var (
+	circleAPIURL = &url.URL{Scheme: "https", Host: "circleci.com", Path: "/api/v1/"}
+)
+
+func circleRequest(path string) (*http.Response, error) {
+	params := url.Values{}
+	params.Add("circle-token", apiKey())
+
+	url := circleAPIURL.ResolveReference(&url.URL{Path: path, RawQuery: params.Encode()})
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf(resp.Status)
+	}
+
+	return resp, nil
+}
+
+func apiKey() string {
+	return os.Getenv(APIEnvKey)
+}
+
+func parseJson(obj interface{}, text io.Reader) {
+	jsonStream, err := ioutil.ReadAll(text)
+	if err != nil {
+		panic(err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(jsonStream))
+
+	for {
+		if err := decoder.Decode(obj); err == io.EOF {
+			break
+		} else if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/circleci/widget.go
+++ b/circleci/widget.go
@@ -1,0 +1,83 @@
+package circleci
+
+import (
+	"fmt"
+	"github.com/olebedev/config"
+	"github.com/senorprogrammer/wtf/wtf"
+)
+
+// Config is a pointer to the global config object
+var Config *config.Config
+
+type Widget struct {
+	wtf.TextWidget
+}
+
+func NewWidget() *Widget {
+	widget := Widget{
+		TextWidget: wtf.NewTextWidget(" CircleCI ", "circleci", false),
+	}
+
+	return &widget
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+func (widget *Widget) Refresh() {
+	if widget.Disabled() {
+		return
+	}
+
+	builds, err := BuildsFor()
+
+	widget.UpdateRefreshedAt()
+
+	widget.View.SetTitle(fmt.Sprintf("%s - Builds", widget.Name))
+
+	if err != nil {
+		widget.View.SetWrap(true)
+		fmt.Fprintf(widget.View, "%v", err)
+	} else {
+		widget.View.SetWrap(false)
+		widget.View.SetText(fmt.Sprintf("%s", widget.contentFrom(builds)))
+	}
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func (widget *Widget) contentFrom(builds []*Build) string {
+	var str string
+	for idx, build := range builds {
+		if idx > 10 {
+			return str
+		}
+
+		str = str + fmt.Sprintf(
+			"[%s] %s-%d (%s) [white]%s\n",
+			buildColor(build),
+			build.Reponame,
+			build.BuildNum,
+			build.Branch,
+			build.AuthorName,
+		)
+	}
+
+	return str
+}
+
+func buildColor(b *Build) string {
+	var color string
+
+	switch b.Status {
+	case "failed":
+		color = "red"
+	case "running":
+		color = "yellow"
+	case "success":
+		color = "green"
+	default:
+		color = "white"
+	}
+
+	return color
+}

--- a/wtf.go
+++ b/wtf.go
@@ -13,6 +13,7 @@ import (
 	"github.com/senorprogrammer/wtf/bamboohr"
 	"github.com/senorprogrammer/wtf/bargraph"
 	"github.com/senorprogrammer/wtf/cfg"
+	"github.com/senorprogrammer/wtf/circleci"
 	"github.com/senorprogrammer/wtf/clocks"
 	"github.com/senorprogrammer/wtf/cmdrunner"
 	"github.com/senorprogrammer/wtf/cryptoexchanges/bittrex"
@@ -175,6 +176,8 @@ func addWidget(app *tview.Application, pages *tview.Pages, widgetName string) {
 		Widgets = append(Widgets, bargraph.NewWidget())
 	case "bittrex":
 		Widgets = append(Widgets, bittrex.NewWidget())
+	case "circleci":
+		Widgets = append(Widgets, circleci.NewWidget())
 	case "clocks":
 		Widgets = append(Widgets, clocks.NewWidget())
 	case "cmdrunner":
@@ -224,6 +227,7 @@ func makeWidgets(app *tview.Application, pages *tview.Pages) {
 	bamboohr.Config = Config
 	bargraph.Config = Config
 	bittrex.Config = Config
+	circleci.Config = Config
 	clocks.Config = Config
 	cmdrunner.Config = Config
 	cryptolive.Config = Config


### PR DESCRIPTION
Hi,

Thanks for the great program. This PR adds support for [CircleCI](https://circleci.com/account/api).  I patterned the module off of the JIRA module. As such, it needs a Circle API token, which can be found at https://circleci.com/account/api. This is passed under the environmental variable WTF_CIRCLE_API_KEY.

The only other note is that I cribbed heavily from [go-circleci](https://github.com/jszwedko/go-circleci) in order to make the client, rather than introduce a new dependency.  The client could be replaced with that library if you are comfortable introducing a new dependency.