### PR TITLE
Allow customization of git module's date and commit formats

### DIFF
--- a/git/git_repo.go
+++ b/git/git_repo.go
@@ -52,7 +52,13 @@ func (repo *GitRepo) changedFiles() []string {
 func (repo *GitRepo) commits() []string {
 	numStr := fmt.Sprintf("-n %d", Config.UInt("wtf.mods.git.commitCount", 10))
 
-	arg := []string{repo.gitDir(), repo.workTree(), "log", "--date=format:\"%b %d, %Y\"", numStr, "--pretty=format:\"[forestgreen]%h [white]%s [grey]%an on %cd[white]\""}
+	dateFormat := Config.UString("wtf.mods.git.dateFormat", "%b %d, %Y")
+	dateStr := fmt.Sprintf("--date=format:\"%s\"", dateFormat)
+
+	commitFormat := Config.UString("wtf.mods.git.commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]")
+	commitStr := fmt.Sprintf("--pretty=format:\"%s\"", commitFormat)
+
+	arg := []string{repo.gitDir(), repo.workTree(), "log", dateStr, numStr, commitStr}
 
 	cmd := exec.Command("git", arg...)
 	str := wtf.ExecuteCommand(cmd)


### PR DESCRIPTION
The existing format for commit logs will remain the default, but
this change allows customization of the `--date=format:` and
`--pretty=format:` arguments passed to `git log`. For example, I
prefer having the time of day a commit was made, and having the
time in front, which can now be done with these options:
```
    git:
      dateFormat: "%H:%M %d %b %y"
      commitFormat: "[forestgreen]%h [grey]%cd [white]%s [grey]%an[white]"
```
(sorry, this doesn't update documentation - if you let me know
what files to edit for those and how to "build" the docs to update
them, I can try to do that better in future changes)