### PR TITLE
Google Calendar: multiple calendars, all-day event date markings

### DIFF
--- a/gcal/client.go
+++ b/gcal/client.go
@@ -17,6 +17,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"time"
+	"sort"
 
 	"github.com/senorprogrammer/wtf/wtf"
 	"golang.org/x/oauth2"
@@ -47,14 +48,57 @@ func Fetch() (*calendar.Events, error) {
 		return nil, err
 	}
 
-	startTime := fromMidnight().Format(time.RFC3339)
-	eventLimit := int64(Config.UInt("wtf.mods.gcal.eventCount", 10))
-	events, err := srv.Events.List("primary").ShowDeleted(false).SingleEvents(true).TimeMin(startTime).MaxResults(eventLimit).OrderBy("startTime").Do()
+	// Get all user calendars with at the least writing access
+	pageToken := ""
+	var calendarIds []string
+	for {
+		calendarList, err := srv.CalendarList.List().ShowHidden(false).MinAccessRole("writer").PageToken(pageToken).Do()
+		for _, calendarListItem := range calendarList.Items {
+			calendarIds = append(calendarIds, calendarListItem.Id)
+		}
+
+		pageToken = calendarList.NextPageToken
+		if err != nil || pageToken == "" {
+			break
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	return events, err
+	// Get calendar events
+	var events calendar.Events
+
+	startTime := fromMidnight().Format(time.RFC3339)
+	eventLimit := int64(Config.UInt("wtf.mods.gcal.eventCount", 10))
+
+	for _, calendarId := range calendarIds {
+		calendarEvents, err := srv.Events.List(calendarId).ShowDeleted(false).TimeMin(startTime).MaxResults(eventLimit).SingleEvents(true).OrderBy("startTime").Do()
+		if err != nil {
+			break
+		}
+		events.Items = append(events.Items, calendarEvents.Items...)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort events
+	timeDateChooser := func(event *calendar.Event) (time.Time, error) {
+		if len(event.Start.Date) > 0 {
+			return time.Parse("2006-01-02", event.Start.Date)
+		} else {
+			return time.Parse(time.RFC3339, event.Start.DateTime)
+		}
+	}
+	sort.Slice(events.Items, func(i, j int) bool {
+		dateA, _ := timeDateChooser(events.Items[i])
+		dateB, _ := timeDateChooser(events.Items[j])
+	  return dateA.Before(dateB)
+	})
+
+	
+	return &events, err
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/gcal/widget.go
+++ b/gcal/widget.go
@@ -133,8 +133,13 @@ func (widget *Widget) eventSummary(event *calendar.Event, conflict bool) string 
 }
 
 func (widget *Widget) eventTimestamp(event *calendar.Event) string {
-	startTime, _ := time.Parse(time.RFC3339, event.Start.DateTime)
-	return startTime.Format(wtf.FriendlyDateTimeFormat)
+	if len(event.Start.Date) > 0 {
+		startTime, _ := time.Parse("2006-01-02", event.Start.Date)
+		return startTime.Format(wtf.FriendlyDateFormat)
+	} else {
+		startTime, _ := time.Parse(time.RFC3339, event.Start.DateTime)
+		return startTime.Format(wtf.FriendlyDateTimeFormat)
+	} 
 }
 
 // eventIsNow returns true if the event is happening now, false if it not

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -13,6 +13,7 @@ import (
 
 const SimpleDateFormat = "Jan 2"
 const SimpleTimeFormat = "15:04 MST"
+const FriendlyDateFormat = "Mon, Jan 2"
 const FriendlyDateTimeFormat = "Mon, Jan 2, 15:04"
 const TimestampFormat = "2006-01-02T15:04:05-0700"
 


### PR DESCRIPTION
The commit alters the gcal-modules events fetching so that:

- Pre-commit: 
1. The gcal Fetch()-method gathered only the users "primary" events,  so for example I had no work-related events listed as those are in a separate calendar ID
2. The widget.. eventTimestamp()-method always displayed the time as "first of January" for the events that had no time, the "all-day" events, on the calendar. 

- Post-commit: 
1. The gcal Fetch()-method gathers all the calendar IDs the user has a write-access on, then combines the resulting calendar events in an array and sorts by the calendar times. 
2. Added a simple correcting if-clause when displaying the timeless-day-events. According to the Google calendar API-docs the calendar.Event.Start.Date -string has a length only when the event is a "all-day" event. (Does not clearly say so but confirmed by trying with the hope of gaining some extra experience points).

This is somewhat related to the issue: https://github.com/senorprogrammer/wtf/issues/47

Issues:

- The commit needs some serious audition and eyeing applied: the committers first time touch with Golang. Had to google how to define variables.. how to loop.. what's what. Please regard the commit as a suggestion and then rewrite, figure it out nicely!

- The gcal.eventCount setting is applied to all the calendars
