### PR TITLE
Fix documentation for logging module

### DIFF
--- a/_site/content/posts/modules/logger.md
+++ b/_site/content/posts/modules/logger.md
@@ -1,5 +1,5 @@
 ---
-title: "Logging"
+title: "Logger"
 date: 2018-06-16T14:22:18-07:00
 draft: false
 ---
@@ -30,7 +30,7 @@ Arrow keys scroll through the log file.
 ## Configuration
 
 ```yaml
-logging:
+logger:
   enabled: true
   position:
     top: 5

--- a/_site/content/posts/modules/logging.md
+++ b/_site/content/posts/modules/logging.md
@@ -9,14 +9,14 @@ Displays the contents of the WTF log file.
 To log to this file in your own modules:
 
 ```golang
-require "github.com/senorprogrammer/wtf/logging"
- logging.Log("This is a log entry")
+require "github.com/senorprogrammer/wtf/logger"
+ logger.Log("This is a log entry")
 ```
 
 ## Source Code
 
 ```bash
-wtf/logging/
+wtf/logger/
 ```
 
 ## Required ENV Variables
@@ -30,7 +30,7 @@ Arrow keys scroll through the log file.
 ## Configuration
 
 ```yaml
-textfile:
+logging:
   enabled: true
   position:
     top: 5

--- a/_site/themes/hyde-hyde/layouts/partials/sidebar.html
+++ b/_site/themes/hyde-hyde/layouts/partials/sidebar.html
@@ -38,7 +38,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/404.html
+++ b/docs/404.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -81,7 +81,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -12,16 +12,16 @@
     
     
     <item>
-      <title>Logging</title>
-      <link>https://wtfutil.com/posts/modules/logging/</link>
+      <title>Logger</title>
+      <link>https://wtfutil.com/posts/modules/logger/</link>
       <pubDate>Sat, 16 Jun 2018 14:22:18 -0700</pubDate>
       
-      <guid>https://wtfutil.com/posts/modules/logging/</guid>
+      <guid>https://wtfutil.com/posts/modules/logger/</guid>
       <description>Displays the contents of the WTF log file.
 To log to this file in your own modules:
-require &amp;#34;github.com/senorprogrammer/wtf/logging&amp;#34; logging.Log(&amp;#34;This is a log entry&amp;#34;) Source Code wtf/logging/ Required ENV Variables None.
+require &amp;#34;github.com/senorprogrammer/wtf/logger&amp;#34; logger.Log(&amp;#34;This is a log entry&amp;#34;) Source Code wtf/logger/ Required ENV Variables None.
 Keyboard Commands Arrow keys scroll through the log file.
-Configuration textfile:enabled:trueposition:top:5left:4height:2width:1refreshInterval:1 Attributes enabled Determines whether or not this module is executed and if its data displayed onscreen. Values: true, false.
+Configuration logger:enabled:trueposition:top:5left:4height:2width:1refreshInterval:1 Attributes enabled Determines whether or not this module is executed and if its data displayed onscreen. Values: true, false.
 position Defines where in the grid this module&amp;rsquo;s widget will be displayed.</description>
     </item>
     

--- a/docs/posts/configuration/attributes/index.html
+++ b/docs/posts/configuration/attributes/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/configuration/index.html
+++ b/docs/posts/configuration/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/configuration/iterm2/index.html
+++ b/docs/posts/configuration/iterm2/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/glossary/index.html
+++ b/docs/posts/glossary/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -81,7 +81,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>
@@ -107,7 +107,7 @@
 <ul class="posts">
     <li>
         <span>
-            <a href="https://wtfutil.com/posts/modules/logging/">Logging</a>
+            <a href="https://wtfutil.com/posts/modules/logger/">Logger</a>
             
             <time class="pull-right post-list">Jun 16, 2018</time>    
             

--- a/docs/posts/index.xml
+++ b/docs/posts/index.xml
@@ -12,16 +12,16 @@
     
     
     <item>
-      <title>Logging</title>
-      <link>https://wtfutil.com/posts/modules/logging/</link>
+      <title>Logger</title>
+      <link>https://wtfutil.com/posts/modules/logger/</link>
       <pubDate>Sat, 16 Jun 2018 14:22:18 -0700</pubDate>
       
-      <guid>https://wtfutil.com/posts/modules/logging/</guid>
+      <guid>https://wtfutil.com/posts/modules/logger/</guid>
       <description>Displays the contents of the WTF log file.
 To log to this file in your own modules:
-require &amp;#34;github.com/senorprogrammer/wtf/logging&amp;#34; logging.Log(&amp;#34;This is a log entry&amp;#34;) Source Code wtf/logging/ Required ENV Variables None.
+require &amp;#34;github.com/senorprogrammer/wtf/logger&amp;#34; logger.Log(&amp;#34;This is a log entry&amp;#34;) Source Code wtf/logger/ Required ENV Variables None.
 Keyboard Commands Arrow keys scroll through the log file.
-Configuration textfile:enabled:trueposition:top:5left:4height:2width:1refreshInterval:1 Attributes enabled Determines whether or not this module is executed and if its data displayed onscreen. Values: true, false.
+Configuration logger:enabled:trueposition:top:5left:4height:2width:1refreshInterval:1 Attributes enabled Determines whether or not this module is executed and if its data displayed onscreen. Values: true, false.
 position Defines where in the grid this module&amp;rsquo;s widget will be displayed.</description>
     </item>
     

--- a/docs/posts/installation/index.html
+++ b/docs/posts/installation/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/bamboohr/index.html
+++ b/docs/posts/modules/bamboohr/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/circleci/index.html
+++ b/docs/posts/modules/circleci/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/clocks/index.html
+++ b/docs/posts/modules/clocks/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/cmdrunner/index.html
+++ b/docs/posts/modules/cmdrunner/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/cryptocurrencies/bittrex/index.html
+++ b/docs/posts/modules/cryptocurrencies/bittrex/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/cryptocurrencies/blockfolio/index.html
+++ b/docs/posts/modules/cryptocurrencies/blockfolio/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/cryptocurrencies/cryptolive/index.html
+++ b/docs/posts/modules/cryptocurrencies/cryptolive/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/gcal/index.html
+++ b/docs/posts/modules/gcal/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/git/index.html
+++ b/docs/posts/modules/git/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/github/index.html
+++ b/docs/posts/modules/github/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/gitlab/index.html
+++ b/docs/posts/modules/gitlab/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/gspreadsheet/index.html
+++ b/docs/posts/modules/gspreadsheet/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/index.html
+++ b/docs/posts/modules/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/ipapi/index.html
+++ b/docs/posts/modules/ipapi/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/ipinfo/index.html
+++ b/docs/posts/modules/ipinfo/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/jenkins/index.html
+++ b/docs/posts/modules/jenkins/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/jira/index.html
+++ b/docs/posts/modules/jira/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/logger/index.html
+++ b/docs/posts/modules/logger/index.html
@@ -10,8 +10,8 @@
 
 <meta name="generator" content="Hugo 0.38.2" />
 
-<title>Logging | WTF - A Terminal Dashboard</title>
-<meta content="Logging - WTF - A Terminal Dashboard" property="og:title">
+<title>Logger | WTF - A Terminal Dashboard</title>
+<meta content="Logger - WTF - A Terminal Dashboard" property="og:title">
 <meta content=" - " property="og:description">
 <!-- CSS -->
 <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>
@@ -102,7 +102,7 @@
 
         <div class="content container">
             <div class="post">
-  <h1>Logging</h1>
+  <h1>Logger</h1>
   
   <div class="col-sm-12 col-md-12">
     <span class="text-left post-date meta">
@@ -123,10 +123,10 @@
 <p>Displays the contents of the WTF log file.</p>
 
 <p>To log to this file in your own modules:</p>
-<div class="highlight"><pre class="chroma"><code class="language-golang" data-lang="golang"><span class="nx">require</span> <span class="s">&#34;github.com/senorprogrammer/wtf/logging&#34;</span>
- <span class="nx">logging</span><span class="p">.</span><span class="nx">Log</span><span class="p">(</span><span class="s">&#34;This is a log entry&#34;</span><span class="p">)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-golang" data-lang="golang"><span class="nx">require</span> <span class="s">&#34;github.com/senorprogrammer/wtf/logger&#34;</span>
+ <span class="nx">logger</span><span class="p">.</span><span class="nx">Log</span><span class="p">(</span><span class="s">&#34;This is a log entry&#34;</span><span class="p">)</span></code></pre></div>
 <h2 id="source-code">Source Code</h2>
-<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">wtf/logging/</code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">wtf/logger/</code></pre></div>
 <h2 id="required-env-variables">Required ENV Variables</h2>
 
 <p>None.</p>
@@ -136,7 +136,7 @@
 <p>Arrow keys scroll through the log file.</p>
 
 <h2 id="configuration">Configuration</h2>
-<div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml">textfile<span class="p">:</span><span class="w">
+<div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml">logger<span class="p">:</span><span class="w">
 </span><span class="w">  </span>enabled<span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="w">
 </span><span class="w">  </span>position<span class="p">:</span><span class="w">
 </span><span class="w">    </span>top<span class="p">:</span><span class="w"> </span><span class="m">5</span><span class="w">

--- a/docs/posts/modules/newrelic/index.html
+++ b/docs/posts/modules/newrelic/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/opsgenie/index.html
+++ b/docs/posts/modules/opsgenie/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/power/index.html
+++ b/docs/posts/modules/power/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/prettyweather/index.html
+++ b/docs/posts/modules/prettyweather/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/security/index.html
+++ b/docs/posts/modules/security/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/textfile/index.html
+++ b/docs/posts/modules/textfile/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/todo/index.html
+++ b/docs/posts/modules/todo/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/modules/weather/index.html
+++ b/docs/posts/modules/weather/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/posts/overview/index.html
+++ b/docs/posts/overview/index.html
@@ -79,7 +79,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,7 +3,7 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
   <url>
-    <loc>https://wtfutil.com/posts/modules/logging/</loc>
+    <loc>https://wtfutil.com/posts/modules/logger/</loc>
     <lastmod>2018-06-16T14:22:18-07:00</lastmod>
   </url>
   

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -81,7 +81,7 @@
         <li class="sidebar-list-item-2"><a href="/posts/modules/ipinfo/">IPInfo</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jenkins/">Jenkins</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/jira/">Jira</a></li>
-        <li class="sidebar-list-item-2"><a href="/posts/modules/logging/">Logging</a></li>
+        <li class="sidebar-list-item-2"><a href="/posts/modules/logger/">Logger</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/newrelic/">New Relic</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/opsgenie/">OpsGenie</a></li>
         <li class="sidebar-list-item-2"><a href="/posts/modules/power/">Power</a></li>

--- a/logger/log.go
+++ b/logger/log.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget() *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(" Logs ", "logging", true),
+		TextWidget: wtf.NewTextWidget(" Logs ", "logger", true),
 
 		filePath: logFilePath(),
 	}

--- a/wtf.go
+++ b/wtf.go
@@ -193,7 +193,7 @@ func addWidget(app *tview.Application, pages *tview.Pages, widgetName string) {
 		Widgets = append(Widgets, jenkins.NewWidget())
 	case "jira":
 		Widgets = append(Widgets, jira.NewWidget())
-	case "logging":
+	case "logger":
 		Widgets = append(Widgets, logger.NewWidget())
 	case "newrelic":
 		Widgets = append(Widgets, newrelic.NewWidget())


### PR DESCRIPTION
https://github.com/senorprogrammer/wtf/commit/6acf1775b84bfd07cc272a0619af822c93385cac 
changed the name of the module but inconsistencies still remain in the documentation and in the widget names.

#### What problem does this solve?
Fix inconsistencies  in naming and documentation for the logging/logger module

#### Is this related to an existing Issue? If so, which one?
No open issues on this
