### PR TITLE
[CircleCi] - Green build color for fixed builds

### DIFF
--- a/circleci/widget.go
+++ b/circleci/widget.go
@@ -72,6 +72,8 @@ func buildColor(build *Build) string {
 		return "yellow"
 	case "success":
 		return "green"
+	case "fixed":
+		return "green"
 	default:
 		return "white"
 	}


### PR DESCRIPTION
If build is successful after a failed build, the status returned by Circleci API is `fixed` instead of `success`.

So it makes sense to show green color build status in that scenario as well.