### PR TITLE
fix documentation for configuring the Gerrit module

### DIFF
--- a/_site/content/posts/modules/gerrit.md
+++ b/_site/content/posts/modules/gerrit.md
@@ -55,10 +55,12 @@ gerrit:
     height: 2
     width: 2
   refreshInterval: 300
+  domain: https://gerrit-review.googlesource.com
   projects:
   - org/test-project"
   - dotfiles
   username: "myname"
+  verifyServerCertificate: false
 ```
 
 ### Attributes
@@ -75,7 +77,7 @@ How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.
 
 `domain` <br />
-_Optional_. Your Gerrit corporate domain. <br />
+Your Gerrit corporate domain. <br />
 Values: A valid URI.
 
 `projects` <br />

--- a/docs/posts/modules/gerrit/index.html
+++ b/docs/posts/modules/gerrit/index.html
@@ -180,10 +180,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </span><span class="w">    </span>height<span class="p">:</span><span class="w"> </span><span class="m">2</span><span class="w">
 </span><span class="w">    </span>width<span class="p">:</span><span class="w"> </span><span class="m">2</span><span class="w">
 </span><span class="w">  </span>refreshInterval<span class="p">:</span><span class="w"> </span><span class="m">300</span><span class="w">
+</span><span class="w">  </span>domain<span class="p">:</span><span class="w"> </span>https<span class="p">:</span>//gerrit-review.googlesource.com<span class="w">
 </span><span class="w">  </span>projects<span class="p">:</span><span class="w">
 </span><span class="w">  </span>-<span class="w"> </span>org/test-project<span class="s2">&#34;
 </span><span class="s2">  - dotfiles
-</span><span class="s2">  username: &#34;</span>myname&#34;</code></pre></div>
+</span><span class="s2">  username: &#34;</span>myname&#34;<span class="w">
+</span><span class="w">  </span>verifyServerCertificate<span class="p">:</span><span class="w"> </span><span class="kc">false</span></code></pre></div>
 <h3 id="attributes">Attributes</h3>
 
 <p><code>enabled</code> <br />
@@ -198,7 +200,7 @@ How often, in seconds, this module will update its data. <br />
 Values: A positive integer, <code>0..n</code>.</p>
 
 <p><code>domain</code> <br />
-<em>Optional</em>. Your Gerrit corporate domain. <br />
+Your Gerrit corporate domain. <br />
 Values: A valid URI.</p>
 
 <p><code>projects</code> <br />


### PR DESCRIPTION
The current documentation incorrectly mentions the gerrit domain is optional. The code however requires this to be set.

This change fixes the documentation