### PR TITLE
Make openFileUtil configurable

### DIFF
--- a/_site/content/posts/configuration/attributes.md
+++ b/_site/content/posts/configuration/attributes.md
@@ -24,6 +24,7 @@ wtf:
     # that support ten line of text, one of three lines, and one of four
     rows: [10, 10, 10, 10, 10, 3, 4]
   # The app redraws itself once a second
+  openFileUtil: open
   refreshInterval: 1
   term: "xterm-256color"
 ```
@@ -64,6 +65,9 @@ Grid</a> for details.
 An array that defines the heights of all the rows. <br />
 Values: See <a href="https://github.com/rivo/tview/wiki/Grid">tview's
 Grid</a> for details.
+
+`openFileUtil` <br />
+Command to use to open a file or URL
 
 `refreshInterval` <br />
 How often, in seconds, the UI refreshes itself. <br />

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -299,7 +299,7 @@ cmd The terminal command to be run, withouth the arguments. Ie: ping, whoami, cu
       
       <guid>https://wtfutil.com/posts/configuration/attributes/</guid>
       <description>The following top-level attributes are configurable in config.yml. See this example config file for more details.
-wtf:colors:background:&amp;#34;red&amp;#34;border:Focusable:&amp;#34;darkslateblue&amp;#34;focused:&amp;#34;orange&amp;#34;normal:&amp;#34;gray&amp;#34;grid:# How _wide_ the columns are, in terminal characters. In this case we have# six columns, each of which are 35 characters widecolumns:[35,35,35,35,35,35]# How _high_ the rows are, in terminal lines. In this case we have five rows# that support ten line of text, one of three lines, and one of fourrows:[10,10,10,10,10,3,4]# The app redraws itself once a secondrefreshInterval:1term:&amp;#34;xterm-256color&amp;#34; Attributes colors.</description>
+wtf:colors:background:&amp;#34;red&amp;#34;border:Focusable:&amp;#34;darkslateblue&amp;#34;focused:&amp;#34;orange&amp;#34;normal:&amp;#34;gray&amp;#34;grid:# How _wide_ the columns are, in terminal characters. In this case we have# six columns, each of which are 35 characters widecolumns:[35,35,35,35,35,35]# How _high_ the rows are, in terminal lines. In this case we have five rows# that support ten line of text, one of three lines, and one of fourrows:[10,10,10,10,10,3,4]# The app redraws itself once a secondopenFileUtil:openrefreshInterval:1term:&amp;#34;xterm-256color&amp;#34; Attributes colors.</description>
     </item>
     
     <item>

--- a/docs/posts/configuration/attributes/index.html
+++ b/docs/posts/configuration/attributes/index.html
@@ -154,6 +154,7 @@ See this <a href="https://github.com/senorprogrammer/wtf/blob/master/_sample_con
 </span><span class="w">    </span><span class="c"># that support ten line of text, one of three lines, and one of four</span><span class="w">
 </span><span class="w">    </span>rows<span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="m">10</span><span class="p">,</span><span class="w"> </span><span class="m">10</span><span class="p">,</span><span class="w"> </span><span class="m">10</span><span class="p">,</span><span class="w"> </span><span class="m">10</span><span class="p">,</span><span class="w"> </span><span class="m">10</span><span class="p">,</span><span class="w"> </span><span class="m">3</span><span class="p">,</span><span class="w"> </span><span class="m">4</span><span class="p">]</span><span class="w">
 </span><span class="w">  </span><span class="c"># The app redraws itself once a second</span><span class="w">
+</span><span class="w">  </span>openFileUtil<span class="p">:</span><span class="w"> </span>open<span class="w">
 </span><span class="w">  </span>refreshInterval<span class="p">:</span><span class="w"> </span><span class="m">1</span><span class="w">
 </span><span class="w">  </span>term<span class="p">:</span><span class="w"> </span><span class="s2">&#34;xterm-256color&#34;</span></code></pre></div>
 <h3 id="attributes">Attributes</h3>
@@ -192,6 +193,9 @@ Grid</a> for details.</p>
 An array that defines the heights of all the rows. <br />
 Values: See <a href="https://github.com/rivo/tview/wiki/Grid">tview&rsquo;s
 Grid</a> for details.</p>
+
+<p><code>openFileUtil</code> <br />
+Command to use to open a file or URL</p>
 
 <p><code>refreshInterval</code> <br />
 How often, in seconds, the UI refreshes itself. <br />

--- a/docs/posts/index.xml
+++ b/docs/posts/index.xml
@@ -299,7 +299,7 @@ cmd The terminal command to be run, withouth the arguments. Ie: ping, whoami, cu
       
       <guid>https://wtfutil.com/posts/configuration/attributes/</guid>
       <description>The following top-level attributes are configurable in config.yml. See this example config file for more details.
-wtf:colors:background:&amp;#34;red&amp;#34;border:Focusable:&amp;#34;darkslateblue&amp;#34;focused:&amp;#34;orange&amp;#34;normal:&amp;#34;gray&amp;#34;grid:# How _wide_ the columns are, in terminal characters. In this case we have# six columns, each of which are 35 characters widecolumns:[35,35,35,35,35,35]# How _high_ the rows are, in terminal lines. In this case we have five rows# that support ten line of text, one of three lines, and one of fourrows:[10,10,10,10,10,3,4]# The app redraws itself once a secondrefreshInterval:1term:&amp;#34;xterm-256color&amp;#34; Attributes colors.</description>
+wtf:colors:background:&amp;#34;red&amp;#34;border:Focusable:&amp;#34;darkslateblue&amp;#34;focused:&amp;#34;orange&amp;#34;normal:&amp;#34;gray&amp;#34;grid:# How _wide_ the columns are, in terminal characters. In this case we have# six columns, each of which are 35 characters widecolumns:[35,35,35,35,35,35]# How _high_ the rows are, in terminal lines. In this case we have five rows# that support ten line of text, one of three lines, and one of fourrows:[10,10,10,10,10,3,4]# The app redraws itself once a secondopenFileUtil:openrefreshInterval:1term:&amp;#34;xterm-256color&amp;#34; Attributes colors.</description>
     </item>
     
     <item>

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -81,7 +81,8 @@ func NamesFromEmails(emails []string) []string {
 // OpenFile opens the file defined in `path` via the operating system
 func OpenFile(path string) {
 	filePath, _ := ExpandHomeDir(path)
-	cmd := exec.Command("open", filePath)
+	openFileUtil := Config.UString("wtf.openFileUtil", "open")
+	cmd := exec.Command(openFileUtil, filePath)
 
 	ExecuteCommand(cmd)
 }


### PR DESCRIPTION
Let user configure the command/utility to use to open a file or URL from within a WTF widget.

This is useful for users that are using wtf on Linux or windows where the 'open' either doesn't exist or does something other than what open does on a mac