### PR TITLE
Fix keyboard command "o" in the todo widget

### DIFF
--- a/todo/widget.go
+++ b/todo/widget.go
@@ -130,7 +130,8 @@ func (widget *Widget) keyboardIntercept(event *tcell.EventKey) *tcell.EventKey {
 		return nil
 	case "o":
 		// Open the file
-		wtf.OpenFile(widget.filePath)
+		confDir, _ := cfg.ConfigDir()
+		wtf.OpenFile(fmt.Sprintf("%s/%s", confDir, widget.filePath))
 		return nil
 	}
 


### PR DESCRIPTION
Pass the full path of the todo file to openFileUtil.

Fix #256