### PR TITLE
Change instances of Github to GitHub to match branding

### DIFF
--- a/_site/content/posts/modules/github.md
+++ b/_site/content/posts/modules/github.md
@@ -4,7 +4,7 @@ date: 2018-05-09T19:20:20-07:00
 draft: false
 ---
 
-Displays information about your git repositories hosted on Github:
+Displays information about your git repositories hosted on GitHub:
 
 
 #### Open Review Requests
@@ -23,21 +23,21 @@ All open pull requests created by you.
 wtf/github/
 ```
 
-## Github Required ENV Variables
+## GitHub Required ENV Variables
 
 <span class="caption">Key:</span> `WTF_GITHUB_TOKEN` <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">Github API</a> token.
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">GitHub API</a> token.
 
 ## GitHub Enterprise Required ENV Variables
 
 <span class="caption">Key:</span> `WTF_GITHUB_TOKEN` <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">Github API</a> token.
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">GitHub API</a> token.
 
 <span class="caption">Key:</span> `WTF_GITHUB_BASE_URL` <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">Github Enterprise</a> API URL.
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">GitHub Enterprise</a> API URL.
 
 <span class="caption">Key:</span> `WTF_GITHUB_UPLOAD_URL` <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">Github Enterprise</a> upload URL (often the same as API URL).
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">GitHub Enterprise</a> upload URL (often the same as API URL).
 
 ## Keyboard Commands
 
@@ -93,11 +93,11 @@ How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.
 
 `repositories` <br />
-A list of key/value pairs each describing a Github repository to fetch data
+A list of key/value pairs each describing a GitHub repository to fetch data
 for. <br />
 <span class="caption">Key:</span> The name of the repository. <br />
 <span class="caption">Value:</span> The name of the account or organization that owns the repository.
 
 `username` <br />
-Your Github username. Used to figure out which review requests you've
+Your GitHub username. Used to figure out which review requests you've
 been added to.

--- a/_site/themes/hyde-hyde/layouts/index.html
+++ b/_site/themes/hyde-hyde/layouts/index.html
@@ -16,7 +16,7 @@
 
   <p>
   Keep an eye on your <strong>OpsGenie</strong> schedules, <strong>Google Calendar</strong>, <strong>Git</strong>
-  and <strong>Github</strong> repositories, and <strong>New Relic</strong> deployments.
+  and <strong>GitHub</strong> repositories, and <strong>New Relic</strong> deployments.
   </p>
 
   <p>
@@ -28,7 +28,7 @@
   </p>
 
   <a href="https://github.com/senorprogrammer/wtf/releases" class="button button-small">Download Latest</a>
-  <a href="https://github.com/senorprogrammer/wtf" class="button button-small">Source on Github</a>
+  <a href="https://github.com/senorprogrammer/wtf" class="button button-small">Source on GitHub</a>
   <a href="https://gitter.im/wtfutil/Lobby" class="button button-small">Chat on Gitter</a>
   <a href="https://twitter.com/wtfutil" class="button button-small">Follow on Twitter</a>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -132,7 +132,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   <p>
   Keep an eye on your <strong>OpsGenie</strong> schedules, <strong>Google Calendar</strong>, <strong>Git</strong>
-  and <strong>Github</strong> repositories, and <strong>New Relic</strong> deployments.
+  and <strong>GitHub</strong> repositories, and <strong>New Relic</strong> deployments.
   </p>
 
   <p>
@@ -144,7 +144,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </p>
 
   <a href="https://github.com/senorprogrammer/wtf/releases" class="button button-small">Download Latest</a>
-  <a href="https://github.com/senorprogrammer/wtf" class="button button-small">Source on Github</a>
+  <a href="https://github.com/senorprogrammer/wtf" class="button button-small">Source on GitHub</a>
   <a href="https://gitter.im/wtfutil/Lobby" class="button button-small">Chat on Gitter</a>
   <a href="https://twitter.com/wtfutil" class="button button-small">Follow on Twitter</a>
 

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -379,13 +379,13 @@ Configuration gcal:colors:title:&amp;#34;red&amp;#34;description:&amp;#34;lightb
       <pubDate>Wed, 09 May 2018 19:20:20 -0700</pubDate>
       
       <guid>https://wtfutil.com/posts/modules/github/</guid>
-      <description>Displays information about your git repositories hosted on Github:
+      <description>Displays information about your git repositories hosted on GitHub:
 Open Review Requests All open code review requests assigned to you.
 Open Pull Requests All open pull requests created by you.
-Source Code wtf/github/ Github Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your Github API token.
-GitHub Enterprise Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your Github API token.
-Key: WTF_GITHUB_BASE_URL Action: Your Github Enterprise API URL.
-Key: WTF_GITHUB_UPLOAD_URL Action: Your Github Enterprise upload URL (often the same as API URL).</description>
+Source Code wtf/github/ GitHub Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your GitHub API token.
+GitHub Enterprise Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your GitHub API token.
+Key: WTF_GITHUB_BASE_URL Action: Your GitHub Enterprise API URL.
+Key: WTF_GITHUB_UPLOAD_URL Action: Your GitHub Enterprise upload URL (often the same as API URL).</description>
     </item>
     
     <item>

--- a/docs/posts/index.xml
+++ b/docs/posts/index.xml
@@ -379,13 +379,13 @@ Configuration gcal:colors:title:&amp;#34;red&amp;#34;description:&amp;#34;lightb
       <pubDate>Wed, 09 May 2018 19:20:20 -0700</pubDate>
       
       <guid>https://wtfutil.com/posts/modules/github/</guid>
-      <description>Displays information about your git repositories hosted on Github:
+      <description>Displays information about your git repositories hosted on GitHub:
 Open Review Requests All open code review requests assigned to you.
 Open Pull Requests All open pull requests created by you.
-Source Code wtf/github/ Github Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your Github API token.
-GitHub Enterprise Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your Github API token.
-Key: WTF_GITHUB_BASE_URL Action: Your Github Enterprise API URL.
-Key: WTF_GITHUB_UPLOAD_URL Action: Your Github Enterprise upload URL (often the same as API URL).</description>
+Source Code wtf/github/ GitHub Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your GitHub API token.
+GitHub Enterprise Required ENV Variables Key: WTF_GITHUB_TOKEN Action: Your GitHub API token.
+Key: WTF_GITHUB_BASE_URL Action: Your GitHub Enterprise API URL.
+Key: WTF_GITHUB_UPLOAD_URL Action: Your GitHub Enterprise upload URL (often the same as API URL).</description>
     </item>
     
     <item>

--- a/docs/posts/modules/bittrex/index.html
+++ b/docs/posts/modules/bittrex/index.html
@@ -99,7 +99,7 @@
             <a href="/posts/modules/git/">Git</a>
           </li>
           <li class="sidebar-list-item-2">
-            <a href="/posts/modules/github/">Github</a>
+            <a href="/posts/modules/github/">GitHub</a>
           </li>
           <li class="sidebar-list-item-2">
             <a href="/posts/modules/gcal/">Google Calendar</a>

--- a/docs/posts/modules/cryptolive/index.html
+++ b/docs/posts/modules/cryptolive/index.html
@@ -96,7 +96,7 @@
             <a href="/posts/modules/git/">Git</a>
           </li>
           <li class="sidebar-list-item-2">
-            <a href="/posts/modules/github/">Github</a>
+            <a href="/posts/modules/github/">GitHub</a>
           </li>
           <li class="sidebar-list-item-2">
             <a href="/posts/modules/gcal/">Google Calendar</a>

--- a/docs/posts/modules/github/index.html
+++ b/docs/posts/modules/github/index.html
@@ -137,7 +137,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   
   
 
-<p>Displays information about your git repositories hosted on Github:</p>
+<p>Displays information about your git repositories hosted on GitHub:</p>
 
 <h4 id="open-review-requests">Open Review Requests</h4>
 
@@ -151,21 +151,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <h2 id="source-code">Source Code</h2>
 <div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">wtf/github/</code></pre></div>
-<h2 id="github-required-env-variables">Github Required ENV Variables</h2>
+<h2 id="github-required-env-variables">GitHub Required ENV Variables</h2>
 
 <p><span class="caption">Key:</span> <code>WTF_GITHUB_TOKEN</code> <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">Github API</a> token.</p>
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">GitHub API</a> token.</p>
 
 <h2 id="github-enterprise-required-env-variables">GitHub Enterprise Required ENV Variables</h2>
 
 <p><span class="caption">Key:</span> <code>WTF_GITHUB_TOKEN</code> <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">Github API</a> token.</p>
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">GitHub API</a> token.</p>
 
 <p><span class="caption">Key:</span> <code>WTF_GITHUB_BASE_URL</code> <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">Github Enterprise</a> API URL.</p>
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">GitHub Enterprise</a> API URL.</p>
 
 <p><span class="caption">Key:</span> <code>WTF_GITHUB_UPLOAD_URL</code> <br />
-<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">Github Enterprise</a> upload URL (often the same as API URL).</p>
+<span class="caption">Action:</span> Your <a href="https://developer.github.com/enterprise/2.13/v3/enterprise-admin/">GitHub Enterprise</a> upload URL (often the same as API URL).</p>
 
 <h2 id="keyboard-commands">Keyboard Commands</h2>
 
@@ -217,13 +217,13 @@ How often, in seconds, this module will update its data. <br />
 Values: A positive integer, <code>0..n</code>.</p>
 
 <p><code>repositories</code> <br />
-A list of key/value pairs each describing a Github repository to fetch data
+A list of key/value pairs each describing a GitHub repository to fetch data
 for. <br />
 <span class="caption">Key:</span> The name of the repository. <br />
 <span class="caption">Value:</span> The name of the account or organization that owns the repository.</p>
 
 <p><code>username</code> <br />
-Your Github username. Used to figure out which review requests you&rsquo;ve
+Your GitHub username. Used to figure out which review requests you&rsquo;ve
 been added to.</p>
 
 </div>

--- a/github/github_repo.go
+++ b/github/github_repo.go
@@ -33,7 +33,7 @@ func NewGithubRepo(name, owner string) *GithubRepo {
 	return &repo
 }
 
-// Refresh reloads the github data via the Github API
+// Refresh reloads the github data via the GitHub API
 func (repo *GithubRepo) Refresh() {
 	repo.PullRequests, _ = repo.loadPullRequests()
 	repo.RemoteRepo, _ = repo.loadRemoteRepository()


### PR DESCRIPTION
The website and code had many instances of referring to GitHub as "Github". I updated all of the references, except for those in the `vendor` directory, to the correct capitalization so that they match the GitHub branding shown on the GitHub website and on Google.