### PR TITLE
Fix modals losing focus

### DIFF
--- a/wtf/focus_tracker.go
+++ b/wtf/focus_tracker.go
@@ -34,6 +34,9 @@ func (tracker *FocusTracker) AssignHotKeys() {
 }
 
 func (tracker *FocusTracker) FocusOn(char string) {
+	if tracker.focusState() == NonWidget {
+		return
+	}
 	for idx, focusable := range tracker.focusables() {
 		if focusable.FocusChar() == char {
 			tracker.blur(tracker.Idx)


### PR DESCRIPTION
To fix #265, return immediately in the `FocusTracker.FocusOn` function if the current state is `AppBoard`.