### PR TITLE
Make the cryptolive using the global config reference.

### DIFF
--- a/cryptoexchanges/cryptolive/price/widget.go
+++ b/cryptoexchanges/cryptolive/price/widget.go
@@ -7,11 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/olebedev/config"
+	"github.com/senorprogrammer/wtf/wtf"
 )
-
-// Config is a pointer to the global config object
-var Config *config.Config
 
 var baseURL = "https://min-api.cryptocompare.com/data/price"
 var ok = true
@@ -35,12 +32,12 @@ func NewWidget() *Widget {
 }
 
 func (widget *Widget) setList() {
-	currenciesMap, _ := Config.Map("wtf.mods.cryptolive.currencies")
+	currenciesMap, _ := wtf.Config.Map("wtf.mods.cryptolive.currencies")
 
 	widget.list = &list{}
 
 	for currency := range currenciesMap {
-		displayName, _ := Config.String("wtf.mods.cryptolive.currencies." + currency + ".displayName")
+		displayName, _ := wtf.Config.String("wtf.mods.cryptolive.currencies." + currency + ".displayName")
 		toList := getToList(currency)
 		widget.list.addItem(currency, displayName, toList)
 	}
@@ -70,10 +67,10 @@ func (widget *Widget) Refresh(wg *sync.WaitGroup) {
 func (widget *Widget) display() {
 	str := ""
 	var (
-		fromNameColor        = Config.UString("wtf.mods.cryptolive.colors.from.name", "coral")
-		fromDisplayNameColor = Config.UString("wtf.mods.cryptolive.colors.from.displayName", "grey")
-		toNameColor          = Config.UString("wtf.mods.cryptolive.colors.to.name", "white")
-		toPriceColor         = Config.UString("wtf.mods.cryptolive.colors.to.price", "green")
+		fromNameColor        = wtf.Config.UString("wtf.mods.cryptolive.colors.from.name", "coral")
+		fromDisplayNameColor = wtf.Config.UString("wtf.mods.cryptolive.colors.from.displayName", "grey")
+		toNameColor          = wtf.Config.UString("wtf.mods.cryptolive.colors.to.name", "white")
+		toPriceColor         = wtf.Config.UString("wtf.mods.cryptolive.colors.to.price", "green")
 	)
 	for _, item := range widget.list.items {
 		str += fmt.Sprintf(" [%s]%s[%s] (%s)\n", fromNameColor, item.displayName, fromDisplayNameColor, item.name)
@@ -87,7 +84,7 @@ func (widget *Widget) display() {
 }
 
 func getToList(fromName string) []*toCurrency {
-	toNames, _ := Config.List("wtf.mods.cryptolive.currencies." + fromName + ".to")
+	toNames, _ := wtf.Config.List("wtf.mods.cryptolive.currencies." + fromName + ".to")
 
 	var toList []*toCurrency
 

--- a/cryptoexchanges/cryptolive/toplist/widget.go
+++ b/cryptoexchanges/cryptolive/toplist/widget.go
@@ -8,11 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/olebedev/config"
+	"github.com/senorprogrammer/wtf/wtf"
 )
 
-// Config is a pointer to the global config object
-var Config *config.Config
 var baseURL = "https://min-api.cryptocompare.com/data/top/exchanges"
 
 type textColors struct {
@@ -50,17 +48,17 @@ func NewWidget() *Widget {
 }
 
 func (widget *Widget) setList() {
-	currenciesMap, _ := Config.Map("wtf.mods.cryptolive.top")
+	currenciesMap, _ := wtf.Config.Map("wtf.mods.cryptolive.top")
 
 	for fromCurrency := range currenciesMap {
-		displayName := Config.UString("wtf.mods.cryptolive.top."+fromCurrency+".displayName", "")
-		limit := Config.UInt("wtf.mods.cryptolive.top."+fromCurrency+".limit", 1)
+		displayName := wtf.Config.UString("wtf.mods.cryptolive.top."+fromCurrency+".displayName", "")
+		limit := wtf.Config.UInt("wtf.mods.cryptolive.top."+fromCurrency+".limit", 1)
 		widget.list.addItem(fromCurrency, displayName, limit, makeToList(fromCurrency, limit))
 	}
 }
 
 func makeToList(fCurrencyName string, limit int) (list []*tCurrency) {
-	toList, _ := Config.List("wtf.mods.cryptolive.top." + fCurrencyName + ".to")
+	toList, _ := wtf.Config.List("wtf.mods.cryptolive.top." + fCurrencyName + ".to")
 
 	for _, toCurrency := range toList {
 		list = append(list, &tCurrency{
@@ -74,11 +72,11 @@ func makeToList(fCurrencyName string, limit int) (list []*tCurrency) {
 
 func (widget *Widget) config() {
 	// set colors
-	widget.colors.from.name = Config.UString("wtf.mods.cryptolive.colors.top.from.name", "coral")
-	widget.colors.from.displayName = Config.UString("wtf.mods.cryptolive.colors.top.from.displayName", "grey")
-	widget.colors.to.name = Config.UString("wtf.mods.cryptolive.colors.top.to.name", "red")
-	widget.colors.to.field = Config.UString("wtf.mods.cryptolive.colors.top.to.field", "white")
-	widget.colors.to.value = Config.UString("wtf.mods.cryptolive.colors.top.to.value", "value")
+	widget.colors.from.name = wtf.Config.UString("wtf.mods.cryptolive.colors.top.from.name", "coral")
+	widget.colors.from.displayName = wtf.Config.UString("wtf.mods.cryptolive.colors.top.from.displayName", "grey")
+	widget.colors.to.name = wtf.Config.UString("wtf.mods.cryptolive.colors.top.to.name", "red")
+	widget.colors.to.field = wtf.Config.UString("wtf.mods.cryptolive.colors.top.to.field", "white")
+	widget.colors.to.value = wtf.Config.UString("wtf.mods.cryptolive.colors.top.to.value", "value")
 }
 
 /* -------------------- Exported Functions -------------------- */

--- a/cryptoexchanges/cryptolive/widget.go
+++ b/cryptoexchanges/cryptolive/widget.go
@@ -4,14 +4,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/olebedev/config"
 	"github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/price"
 	"github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/toplist"
 	"github.com/senorprogrammer/wtf/wtf"
 )
-
-// Config is a pointer to the global config object
-var Config *config.Config
 
 // Widget define wtf widget to register widget later
 type Widget struct {
@@ -22,9 +18,6 @@ type Widget struct {
 
 // NewWidget Make new instance of widget
 func NewWidget() *Widget {
-	price.Config = Config
-	toplist.Config = Config
-
 	widget := Widget{
 		TextWidget:    wtf.NewTextWidget(" CryptoLive ", "cryptolive", false),
 		priceWidget:   price.NewWidget(),


### PR DESCRIPTION
`Config` property of the `cryptolive` widget is not initialized upon start.
Re-used the global config reference from `wtf.Config`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5e1e26]

goroutine 1 [running]:
github.com/senorprogrammer/wtf/vendor/github.com/olebedev/config.(*Config).Map(0x0, 0xb96165, 0x1e, 0xa, 0xa210e0, 0xc420157ab8)
        /home/user/go/src/github.com/senorprogrammer/wtf/vendor/github.com/olebedev/config/config.go:274 +0x26
github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/price.(*Widget).setList(0xc4201bd800)
        /home/user/go/src/github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/price/widget.go:38 +0x54
github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/price.NewWidget(0xb88b12)
        /home/user/go/src/github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/price/widget.go:32 +0x40
github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive.NewWidget(0xc4200afd60)
        /home/user/go/src/github.com/senorprogrammer/wtf/cryptoexchanges/cryptolive/widget.go:30 +0xdf
main.addWidget(0xc4201efa40, 0xc4201e4c60, 0xc4200afd60, 0xa)
        /home/user/go/src/github.com/senorprogrammer/wtf/main.go:189 +0x22a7
main.makeWidgets(0xc4201efa40, 0xc4201e4c60)
        /home/user/go/src/github.com/senorprogrammer/wtf/main.go:249 +0x191
main.main()
        /home/user/go/src/github.com/senorprogrammer/wtf/main.go:277 +0x1d5
exit status 2
```