### PR TITLE
Fix issue with date comparison on the 1st of the month

### DIFF
--- a/gcal/display.go
+++ b/gcal/display.go
@@ -83,7 +83,15 @@ func (widget *Widget) dayDivider(event, prevEvent *CalEvent) string {
 		prevStartTime = prevEvent.Start()
 	}
 
-	if event.Start().Day() != prevStartTime.Day() {
+	// round times to midnight for comparison
+	toMidnight := func(t time.Time) time.Time {
+		t = t.Local()
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	}
+	prevStartDay := toMidnight(prevStartTime)
+	eventStartDay := toMidnight(event.Start())
+
+	if !eventStartDay.Equal(prevStartDay) {
 
 		return fmt.Sprintf("[%s::b]",
 			wtf.Config.UString("wtf.mods.gcal.colors.day", "forestgreen")) +


### PR DESCRIPTION
Today, August 1st, I was surprised to see WTF missing the date
header over my calendar events. It turns out that when I extended
the `dayDivider` function to use a default (epoch) time for
considering whether to print a header over the first event (when
`prevEvent == nil`), I didn't consider that 1 out of every ~30
days will happen to have the same day of the month as the epoch
time.

To fix this and make date headers show up on the 1st of the month
again, dates are truncated to midnight and compared for equality,
rather than just comparing a component of them.

I *think* converting times to local time before truncating to
midnight is the correct way to do this - otherwise, midnight in
one time zone would never equal midnight in another time zone. As
it happens, all my meetings take place in San Francisco, so I'm not
the best test vector for how this works with meetings/calls in
different time zones.