### PR TITLE
Update ConfigDir()

### DIFF
--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -100,7 +100,7 @@ func CreateConfigFile() {
 
 // CreateFile creates the named file in the config directory, if it does not already exist.
 // If the file exists it does not recreate it.
-// If successful, returns the absolute path to the file
+// If successful, eturns the absolute path to the file
 // If unsuccessful, returns an error
 func CreateFile(fileName string) (string, error) {
 	configDir, err := ConfigDir()

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -55,7 +55,12 @@ func MigrateOldConfig() {
 
 // ConfigDir returns the absolute path to the configuration directory
 func ConfigDir() (string, error) {
-	configDir, err := wtf.ExpandHomeDir(ConfigDirV2)
+	filePath := ConfigDirV2
+	if len(wtf.ConfigPath) > 0 {
+		filePath = wtf.ConfigPath
+	}
+
+	configDir, err := wtf.ExpandHomeDir(filePath)
 	if err != nil {
 		return "", err
 	}
@@ -95,7 +100,7 @@ func CreateConfigFile() {
 
 // CreateFile creates the named file in the config directory, if it does not already exist.
 // If the file exists it does not recreate it.
-// If successful, eturns the absolute path to the file
+// If successful, returns the absolute path to the file
 // If unsuccessful, returns an error
 func CreateFile(fileName string) (string, error) {
 	configDir, err := ConfigDir()

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -100,7 +100,7 @@ func CreateConfigFile() {
 
 // CreateFile creates the named file in the config directory, if it does not already exist.
 // If the file exists it does not recreate it.
-// If successful, eturns the absolute path to the file
+// If successful, returns the absolute path to the file
 // If unsuccessful, returns an error
 func CreateFile(fileName string) (string, error) {
 	configDir, err := ConfigDir()

--- a/main.go
+++ b/main.go
@@ -296,9 +296,10 @@ func main() {
 	pages.AddPage("grid", display.Grid, true, true)
 	app.SetInputCapture(keyboardIntercept)
 
+	configPath, _ := cfg.ConfigDir()
 	// Loop in a routine to redraw the screen
 	go redrawApp(app)
-	go watchForConfigChanges(app, flags.Config, display.Grid, pages)
+	go watchForConfigChanges(app, configPath, display.Grid, pages)
 
 	if err := app.SetRoot(pages, true).Run(); err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -105,6 +105,10 @@ func loadConfigFile(filePath string) {
 	wtf.Config = Config
 }
 
+func setConfigPath(filePath string) {
+	wtf.ConfigPath = filePath
+}
+
 // redrawApp redraws the rendered views to screen on a defined interval (set in config.yml)
 // Use this because each textView widget can have it's own update interval, and I don't want to
 // manage drawing co-ordination amongst them all. If you need to have a
@@ -274,6 +278,7 @@ func main() {
 	cfg.CreateConfigDir()
 	cfg.CreateConfigFile()
 	loadConfigFile(flags.ConfigFilePath())
+	setConfigPath(flags.ConfigFilePath())
 
 	if flags.Profile {
 		defer profile.Start(profile.MemProfile).Stop()

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -9,6 +9,7 @@ import (
 )
 
 var Config *config.Config
+var ConfigPath string
 
 type TextWidget struct {
 	enabled   bool


### PR DESCRIPTION
# Changes 🔧
- `wtf --config=path/to/your/config.yml` can now handle absolute paths (only handled relative path before)
- `cfg.ConfigDir()` now returns the directory of the custom path (used to only return default path)
- Fix typo in `config_files.go`

# Context 📖 
The purpose of these changes is so that I can use `ConfigDir()` to find the `config.yml` filepath and eventually write to it.

# Notes 📓
I created a package variable for `wtf.ConfigPath` since I can't add on top of the `wtf.Config` variable struct since it is taken from a third party package. Open to input if you prefer a different place/method of encapsulation.