### PR TITLE
Add Bearer Token resources in twitter documentation

### DIFF
--- a/_site/content/posts/modules/twitter.md
+++ b/_site/content/posts/modules/twitter.md
@@ -10,6 +10,9 @@ Connects to the Twitter API and displays a single user's tweets.
 
 NOTE: This only works for single-application developer accounts for now.
 
+To get your bearer token, please see:
+https://github.com/Trinergy/twitter_bearer_token
+
 ## Source Code
 
 ```bash


### PR DESCRIPTION
I have added the Bearer Token getter tool in a separate repo and updated the documentation.

This is an intermediate step towards automating the authentication process on initialization and writing to the `config.yml` eventually.