### PR TITLE
Make google calendar focussable

### DIFF
--- a/gcal/display.go
+++ b/gcal/display.go
@@ -33,6 +33,7 @@ func (widget *Widget) display() {
 	defer widget.mutex.Unlock()
 
 	_, timedEvents := widget.sortedEvents()
+	widget.View.SetTitle(widget.ContextualTitle(widget.Name))
 	widget.View.SetText(widget.contentFrom(timedEvents))
 }
 

--- a/gcal/widget.go
+++ b/gcal/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget() *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget("Calendar", "gcal", false),
+		TextWidget: wtf.NewTextWidget("Calendar", "gcal", true),
 		ch:         make(chan struct{}),
 	}
 


### PR DESCRIPTION
When there are lot of events, the content in teh widget is hidden and there is no way to view the  upcoming events. Making the widget focussable allows for one to scroll through the list of calendar events using the arrow keys