### PR TITLE
fixed incorrect to apiKey instead of 'subdomain' in subdomain()

### DIFF
--- a/zendesk/client.go
+++ b/zendesk/client.go
@@ -25,8 +25,8 @@ func apiKey() string {
 
 func subdomain() string {
 	return wtf.Config.UString(
-		"wtf.mods.zendesk.apiKey",
-		os.Getenv("ZENDESK_API"),
+		"wtf.mods.zendesk.subdomain",
+		os.Getenv("ZENDESK_SUBDOMAIN"),
 	)
 }
 


### PR DESCRIPTION
Function subdomain() was calling to the API key variable since update in how API tokens are referenced. 