### PR TITLE
Clock format

### DIFF
--- a/_site/content/modules/clocks.md
+++ b/_site/content/modules/clocks.md
@@ -55,6 +55,10 @@ The foreground color for the odd-numbered rows. <br />
 Values: Any <a href="https://en.wikipedia.org/wiki/X11_color_names">X11
 color name</a>.
 
+`dateFormat` <br />
+The format of the date string for all clocks. <br />
+Values: Any valid Go date layout which is handled by <a href="https://golang.org/pkg/time/#Time.Format">Time.Format</a>. Defaults to Jan 2.
+
 `enabled` <br />
 Determines whether or not this module is executed and if its data displayed onscreen. <br />
 Values: `true`, `false`.
@@ -77,3 +81,7 @@ Defines the display order of the clocks in the widget. <br />
 Values: `alphabetical` or `chronological`. `alphabetical` will sort in
 acending order by `key`, `chronological` will sort in ascending order by
 date/time.
+
+`timeFormat` <br />
+The format of the time string for all clocks. <br />
+Values: Any valid Go time layout which is handled by <a href="https://golang.org/pkg/time/#Time.Format">Time.Format</a>. Defaults to 15:04 MST.

--- a/clocks/clock.go
+++ b/clocks/clock.go
@@ -2,8 +2,6 @@ package clocks
 
 import (
 	"time"
-
-	"github.com/senorprogrammer/wtf/wtf"
 )
 
 type Clock struct {
@@ -20,8 +18,8 @@ func NewClock(label string, timeLoc *time.Location) Clock {
 	return clock
 }
 
-func (clock *Clock) Date() string {
-	return clock.LocalTime().Format(wtf.SimpleDateFormat)
+func (clock *Clock) Date(dateFormat string) string {
+	return clock.LocalTime().Format(dateFormat)
 }
 
 func (clock *Clock) LocalTime() time.Time {
@@ -32,6 +30,6 @@ func (clock *Clock) ToLocal(t time.Time) time.Time {
 	return t.In(clock.Location)
 }
 
-func (clock *Clock) Time() string {
-	return clock.LocalTime().Format(wtf.SimpleTimeFormat)
+func (clock *Clock) Time(timeFormat string) string {
+	return clock.LocalTime().Format(timeFormat)
 }

--- a/clocks/display.go
+++ b/clocks/display.go
@@ -6,7 +6,7 @@ import (
 	"github.com/senorprogrammer/wtf/wtf"
 )
 
-func (widget *Widget) display(clocks []Clock) {
+func (widget *Widget) display(clocks []Clock, dateFormat string, timeFormat string) {
 	if len(clocks) == 0 {
 		widget.View.SetText(fmt.Sprintf("\n%s", " no timezone data available"))
 		return
@@ -18,8 +18,8 @@ func (widget *Widget) display(clocks []Clock) {
 			" [%s]%-12s %-10s %7s[white]\n",
 			wtf.RowColor("clocks", idx),
 			clock.Label,
-			clock.Time(),
-			clock.Date(),
+			clock.Time(timeFormat),
+			clock.Date(dateFormat),
 		)
 	}
 

--- a/clocks/widget.go
+++ b/clocks/widget.go
@@ -11,7 +11,9 @@ import (
 type Widget struct {
 	wtf.TextWidget
 
-	clockColl ClockCollection
+	clockColl  ClockCollection
+	dateFormat string
+	timeFormat string
 }
 
 func NewWidget(app *tview.Application) *Widget {
@@ -21,6 +23,9 @@ func NewWidget(app *tview.Application) *Widget {
 
 	widget.clockColl = widget.buildClockCollection(wtf.Config.UMap("wtf.mods.clocks.locations"))
 
+	widget.dateFormat = wtf.Config.UString("wtf.mods.clocks.dateFormat", wtf.SimpleDateFormat)
+	widget.timeFormat = wtf.Config.UString("wtf.mods.clocks.timeFormat", wtf.SimpleTimeFormat)
+
 	return &widget
 }
 
@@ -28,7 +33,7 @@ func NewWidget(app *tview.Application) *Widget {
 
 func (widget *Widget) Refresh() {
 	widget.UpdateRefreshedAt()
-	widget.display(widget.clockColl.Sorted())
+	widget.display(widget.clockColl.Sorted(), widget.dateFormat, widget.timeFormat)
 }
 
 /* -------------------- Unexported Functions -------------------- */


### PR DESCRIPTION
I prefer 12-hour am/pm times instead of 24-hour time. This PR adds two new optional attributes for the clock module, to support custom formats for date and time.