### PR TITLE
Display all day events in calendar

### DIFF
--- a/gcal/cal_event.go
+++ b/gcal/cal_event.go
@@ -69,33 +69,37 @@ func (calEvent *CalEvent) ResponseFor(email string) string {
 
 func (calEvent *CalEvent) End() time.Time {
 	var calcTime string
+	var end time.Time
 
 	if calEvent.AllDay() {
 		calcTime = calEvent.event.End.Date
+		end, _ = time.ParseInLocation("2006-01-02", calcTime, time.Local)
 	} else {
 		calcTime = calEvent.event.End.DateTime
+		end, _ = time.Parse(time.RFC3339, calcTime)
 	}
 
-	end, _ := time.Parse(time.RFC3339, calcTime)
 	return end
 }
 
 func (calEvent *CalEvent) Start() time.Time {
 	var calcTime string
+	var start time.Time
 
 	if calEvent.AllDay() {
 		calcTime = calEvent.event.Start.Date
+		start, _ = time.ParseInLocation("2006-01-02", calcTime, time.Local)
 	} else {
 		calcTime = calEvent.event.Start.DateTime
+		start, _ = time.Parse(time.RFC3339, calcTime)
 	}
 
-	start, _ := time.Parse(time.RFC3339, calcTime)
 	return start
 }
 
 func (calEvent *CalEvent) Timestamp() string {
 	if calEvent.AllDay() {
-		startTime, _ := time.Parse("2006-01-02", calEvent.event.Start.Date)
+		startTime, _ := time.ParseInLocation("2006-01-02", calEvent.event.Start.Date, time.Local)
 		return startTime.Format(wtf.FriendlyDateFormat)
 	}
 

--- a/gcal/display.go
+++ b/gcal/display.go
@@ -32,9 +32,8 @@ func (widget *Widget) display() {
 	widget.mutex.Lock()
 	defer widget.mutex.Unlock()
 
-	_, timedEvents := widget.sortedEvents()
 	widget.View.SetTitle(widget.ContextualTitle(widget.Name))
-	widget.View.SetText(widget.contentFrom(timedEvents))
+	widget.View.SetText(widget.contentFrom(widget.calEvents))
 }
 
 func (widget *Widget) contentFrom(calEvents []*CalEvent) string {
@@ -51,6 +50,9 @@ func (widget *Widget) contentFrom(calEvents []*CalEvent) string {
 
 	for _, calEvent := range calEvents {
 		timestamp := fmt.Sprintf("[%s]%s", widget.descriptionColor(calEvent), calEvent.Timestamp())
+		if calEvent.AllDay() {
+			timestamp = ""
+		}
 
 		title := fmt.Sprintf("[%s]%s",
 			widget.titleColor(calEvent),


### PR DESCRIPTION
All day events were being excluded from the calendar.  It looks like they were excluded due to time zone issues, parsing the date would result in a UTC time which would display under the previous date due to the time zone difference.

![selection_009](https://user-images.githubusercontent.com/2496835/46453083-57dbc100-c754-11e8-907a-7c9933f2e154.png)

All day events will display without a time. 
