### PR TITLE
Suspend app to make authenticating for google calendar easier

### DIFF
--- a/gcal/client.go
+++ b/gcal/client.go
@@ -142,7 +142,7 @@ func authenticate() {
 func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
 	fmt.Printf("Go to the following link in your browser then type the "+
-		"authorization code: \n%v\n", authURL)
+		"authorization code: \n%v (press 'return' before inserting the code)", authURL)
 
 	var code string
 	if _, err := fmt.Scan(&code); err != nil {


### PR DESCRIPTION
The initial setup for google calendar is quite complicated.
With this pull request the app gets suspended when the tokens are not available and the link for authenticating is printed.

Unfortunately, there is still a small (known) bug in `tview` (https://github.com/gdamore/tcell/issues/194) that looses a keyboard event after suspending the app, which requires users to hit enter before inserting the approval code from google.

Also, the tokens are now stored in `.config/wtf/` instead of `~./credentials`.