### PR TITLE
add static hot key assignments for text widgets

### DIFF
--- a/wtf/focus_tracker.go
+++ b/wtf/focus_tracker.go
@@ -29,9 +29,25 @@ func (tracker *FocusTracker) AssignHotKeys() {
 		return
 	}
 
+	usedKeys := make(map[string]bool)
+	focusables := tracker.focusables()
 	i := 1
 
-	for _, focusable := range tracker.focusables() {
+	for _, focusable := range focusables {
+		if focusable.FocusChar() != "" {
+			usedKeys[focusable.FocusChar()] = true
+		}
+	}
+	for _, focusable := range focusables {
+		if focusable.FocusChar() != "" {
+			continue
+		}
+		if _, foundKey := usedKeys[string('0'+i)]; foundKey {
+			for ; foundKey; _, foundKey = usedKeys[string('0'+i)] {
+				i++
+			}
+		}
+
 		// Don't have nav characters > "9"
 		if i >= 10 {
 			break

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -22,10 +22,16 @@ type TextWidget struct {
 }
 
 func NewTextWidget(app *tview.Application, name string, configKey string, focusable bool) TextWidget {
-	widget := TextWidget{
-		enabled:   Config.UBool(fmt.Sprintf("wtf.mods.%s.enabled", configKey), false),
-		focusable: focusable,
+	focusCharValue := Config.UInt(fmt.Sprintf("wtf.mods.%s.focusChar", configKey), -1)
+	focusChar := string('0' + focusCharValue)
+	if focusCharValue == -1 {
+		focusChar = ""
+	}
 
+	widget := TextWidget{
+		enabled:    Config.UBool(fmt.Sprintf("wtf.mods.%s.enabled", configKey), false),
+		focusable:  focusable,
+		focusChar:  focusChar,
 		Name:       Config.UString(fmt.Sprintf("wtf.mods.%s.title", configKey), name),
 		RefreshInt: Config.UInt(fmt.Sprintf("wtf.mods.%s.refreshInterval", configKey)),
 	}


### PR DESCRIPTION
This commit allows configuring static hot key assignments. Just add the key focusChar to a focusable widget and the predefined focusChar will be set.
This closes #330 

There is one open problem if two widgets are configured with the same focusChar then only one can be accessed via the hot keys. But before I resolve this I would like to get a first feedback to the change.

For the duplicate focusChar I see the following solutions:

1. Leave as it is, it is visible to the user that there are multiple widgets with the same focusChar
2. If there are multiple widgets with the same focusChar, use the next free hot key
3. If there are multiple widgets with the same focusChar, show an error (but this is something for #313)